### PR TITLE
Node Update - Relative Links + broken image removal

### DIFF
--- a/node/install-and-update/become-a-full-archive-node.md
+++ b/node/install-and-update/become-a-full-archive-node.md
@@ -2,6 +2,4 @@
 
 1. Wait until your local Node will be synced. Syncing should happen automatically after X minutes.
 
-![node-synced](https://staticassetsshare.s3-us-west-2.amazonaws.com/validator/node-synced.png)
-
 Congratulations! Your Full / Archive Node is ready for use!

--- a/node/install-and-update/become-a-validator.md
+++ b/node/install-and-update/become-a-validator.md
@@ -2,11 +2,11 @@
 
 From this section you will know how to become a Validator.
 
-1. Create a `Stash` account by following the [instructions](https://cere-network.gitbook.io/cere-network/tools/cere-explorer/how-to-create-an-account-by-using-cere-explorer).
-2. Create a `Controller` account by following the [instructions](https://cere-network.gitbook.io/cere-network/tools/cere-explorer/how-to-create-an-account-by-using-cere-explorer).
+1. Create a `Stash` account by following the [instructions](/tools/cere-explorer/how-to-create-an-account-by-using-cere-explorer.md).
+2. Create a `Controller` account by following the [instructions](/tools/cere-explorer/how-to-create-an-account-by-using-cere-explorer.md).
 3. **Testnets Only!** - **** Fund Stash and Controller accounts with native tokens by using [Cere FriendBot](https://laboratory.cere.network/#/friend-bot) (you can take accounts public keys in the [Account tab in the Cere Explorer ](https://explorer.cere.network/#/accounts)by clicking on the round icon left to the account name).
 4. Wait until your local Node will be synced. Syncing should happen automatically after X minutes.
-5. Add a Validator via [Cere Explorer](https://explorer.cere.network/) (check [here](https://cere-network.gitbook.io/cere-network/tools/cere-explorer/how-to-connect-to-your-node-with-cere-explorer) how to connect to your node).
+5. Add a Validator via [Cere Explorer](https://explorer.cere.network/) (check [here](/tools/cere-explorer/how-to-connect-to-your-node-with-cere-explorer.md) how to connect to your node).
    1. Generate `Session Key`.
       1. Go to `Developer` → `RPC calls.`
       2. Select `author` → `rotateKeys()` function.

--- a/node/install-and-update/become-a-validator.md
+++ b/node/install-and-update/become-a-validator.md
@@ -4,7 +4,7 @@ From this section you will know how to become a Validator.
 
 1. Create a `Stash` account by following the [instructions](/tools/cere-explorer/how-to-create-an-account-by-using-cere-explorer.md).
 2. Create a `Controller` account by following the [instructions](/tools/cere-explorer/how-to-create-an-account-by-using-cere-explorer.md).
-3. **Testnets Only!** - **** Fund Stash and Controller accounts with native tokens by using [Cere FriendBot](https://laboratory.cere.network/#/friend-bot) (you can take accounts public keys in the [Account tab in the Cere Explorer ](https://explorer.cere.network/#/accounts)by clicking on the round icon left to the account name).
+3. **Testnets Only!** - **** Fund Stash and Controller accounts with native tokens by using [Cere FriendBot](https://stats.cere.network/#/friend-bot) (you can take accounts public keys in the [Account tab in the Cere Explorer ](https://explorer.cere.network/#/accounts)by clicking on the round icon left to the account name).
 4. Wait until your local Node will be synced. Syncing should happen automatically after X minutes.
 5. Add a Validator via [Cere Explorer](https://explorer.cere.network/) (check [here](/tools/cere-explorer/how-to-connect-to-your-node-with-cere-explorer.md) how to connect to your node).
    1. Generate `Session Key`.

--- a/node/install-and-update/become-a-validator.md
+++ b/node/install-and-update/become-a-validator.md
@@ -26,7 +26,7 @@ From this section you will know how to become a Validator.
       7. Press `Bond & Validate`
       8. Press `Sign and Submit`
 6. **IGNORE if you completed #5, BETA!** - Add a Validator by using an automated script.
-   1.  Replace the [./scripts/validator/.env](https://github.com/Cerebellum-Network/nodes-installation-scripts/blob/master/scripts/validator/.env) with appropriate values.
+   1.  Replace the [.env.* config](https://github.com/Cerebellum-Network/nodes-installation-scripts/tree/master/configs) with appropriate values.
 
        | Parameter                     | Description                                                        |
        | ----------------------------- | ------------------------------------------------------------------ |
@@ -38,9 +38,9 @@ From this section you will know how to become a Validator.
    2.  Run the script.
 
        ```
-            docker-compose --env-file ./scripts/validator/.env up add_validator
+            docker-compose --env-file $CONFIG_FILE up add_validator
        ```
    3. Once it is finished, you should be able to see `Validator added successfully!` message.
-   4. Clean up the values in [./scripts/validator/.env](https://github.com/Cerebellum-Network/nodes-installation-scripts/blob/master/scripts/validator/.env).
+   4. Clean up the values in your .env config file
 
 Congratulations! Now your Validator is in a waiting state.

--- a/node/install-and-update/how-to-fix-environment-errors.md
+++ b/node/install-and-update/how-to-fix-environment-errors.md
@@ -1,9 +1,9 @@
 # How to fix environment errors
 
 1. ✘ Please change `chain-data` folder permission to 777.
-   * Add permission to the `chain-data` folder by following the instructions in the `Start a Node` section [point #2](https://cere-network.gitbook.io/cere-network/node/install-and-update/start-a-node#start-a-node).
+   * Add permission to the `chain-data` folder by following the instructions in the `Start a Node` section [point #2](/node/install-and-update/start-a-node#start-a-node.md).
 2. ✘ Please install NTP Time Server or reconfigure your NTP Time Server.
-   * Install NTP Time Server by following the [instructions](https://cere-network.gitbook.io/cere-network/node/install-and-update/install-and-configure-network-time-protocol-ntp-client).
+   * Install NTP Time Server by following the [instructions](/node/install-and-update/install-and-configure-network-time-protocol-ntp-client.md).
 3. ✘ Please install `lsof` or open your node port `9944`.
    *   Install `lsof` by following the commands:
 
@@ -12,4 +12,4 @@
        sudo apt-get install -y lsof
        ```
    * Check docker container opened ports by following the command:`docker ps`
-   * Recreate the docker container by following the instructions in the `Start a Node` section [point #6](https://cere-network.gitbook.io/cere-network/node/install-and-update/start-a-node#start-a-node).
+   * Recreate the docker container by following the instructions in the `Start a Node` section [point #6](/node/install-and-update/start-a-node.md#start-a-node).

--- a/node/install-and-update/start-a-node.md
+++ b/node/install-and-update/start-a-node.md
@@ -5,7 +5,7 @@
 1. [Install Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 2. [Install Docker](https://docs.docker.com/get-docker/)
 3. [Install Docker Compose 1.25.0+](https://docs.docker.com/compose/install/)
-4. [Install & Configure Network Time Protocol (NTP) Client - Linux only](https://cere-network.gitbook.io/cere-network/node/install-and-update/install-and-configure-network-time-protocol-ntp-client)
+4. [Install & Configure Network Time Protocol (NTP) Client - Linux only](/node/install-and-update/install-and-configure-network-time-protocol-ntp-client.md)
 
 ## **Start a Node**
 
@@ -61,8 +61,8 @@ To run a Node on your host, please, follow the steps below.
      Mar 03 14:42:23.973  INFO Local node identity is: 12D3KooWLafVQ2XGQS8A3rdj9t8rX5UFcVGxtx8a9vgQsYJi7Rdz (legacy representation: 12D3KooWLafVQ2XGQS8A3rdj9t8rX5UFcVGxtx8a9vgQsYJi7Rdz)
     ```
 
-    If you can not see the output in more than 2 minutes you should check node logs. Use the [instructions](https://cere-network.gitbook.io/cere-network/node/install-and-update/node-logs) to know more about logs and their set up.
-8. Launch [Cere Explorer ](https://explorer.cere.network/)and [connect to your node](https://cere-network.gitbook.io/cere-network/tools/cere-explorer/how-to-connect-to-your-node-with-cere-explorer). You can check the Node's `syncing` status. To do this go to the `Network` -> `Explorer` -> `Node info`. It should be equal to `yes` or `no` (synced already).
+    If you can not see the output in more than 2 minutes you should check node logs. Use the [instructions](/node/install-and-update/node-logs.md) to know more about logs and their set up.
+8. Launch [Cere Explorer ](https://explorer.cere.network/)and [connect to your node](/tools/cere-explorer/how-to-connect-to-your-node-with-cere-explorer.md). You can check the Node's `syncing` status. To do this go to the `Network` -> `Explorer` -> `Node info`. It should be equal to `yes` or `no` (synced already).
 
 Congratulations! You've successfully started a Node on your host. \
 \

--- a/tools/cere-explorer/how-to-connect-to-your-node-with-cere-explorer.md
+++ b/tools/cere-explorer/how-to-connect-to-your-node-with-cere-explorer.md
@@ -16,6 +16,6 @@
 
 ### Your Node is on a localhost
 
-1. Execute steps 2-4 from your Node is on a remote host [section](https://cere-network.gitbook.io/cere-network/tools/cere-explorer/how-to-connect-to-your-node-with-cere-explorer).
+1. Execute steps 2-4 from your Node is on a remote host [section](/tools/cere-explorer/how-to-connect-to-your-node-with-cere-explorer.md).
 2. You are done.
 


### PR DESCRIPTION
Old links were still pointing to the previous gitbook instance which is obsolete. Updated to use relative links which point at the this source book. Plus i removed one broken image which wasn't adding much value being broken anyway.