### PR TITLE
Added details about pre-sealed block log when rotatingKeys

### DIFF
--- a/node/install-and-update/update-a-validator-node.md
+++ b/node/install-and-update/update-a-validator-node.md
@@ -43,7 +43,7 @@ Machine B - a machine where Validator B is hosting
 11\. Press `Set session key`.
 
 12\. **!Important** Wait until the message `Pre-sealed block for proposal at` **appears** in Validator B and **disappears** in Validator A logs. You can do this by running the following command in the Validator Nodes root directory:\
-\*\*\*\*`docker-compose logs -f --tail=1000 | grep "Pre-sealed block for proposal at"`
+\*\*\*\*`docker-compose logs -f --tail=1000 | grep "Pre-sealed block for proposal at"`. Change should happen once the current era ends and the next era begins.
 
 13\. Now you can safely stop Validator A using command: `docker-compose stop add_validator_node_custom` in order to update either Validator A itself or Machine A.
 


### PR DESCRIPTION
This is something I was wondering because the pre-sealed block log wasn't showing after a successful `rotateKeys` call. And if I understood correctly, a validator change happens only once an era ends.